### PR TITLE
ErrorDisplay added with filtering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13766,6 +13766,15 @@
         "whatwg-fetch": "^3.4.1"
       }
     },
+    "react-debounce-input": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/react-debounce-input/-/react-debounce-input-3.2.3.tgz",
+      "integrity": "sha512-7Bfjm9sxrtgB+IsSrdXoo4CVqKg7CbWC68dNhr8q7ZmY6C0AqtR524//SenHQWT+eeSG9DmSLWNWCUFSyaaWSQ==",
+      "requires": {
+        "lodash.debounce": "^4",
+        "prop-types": "^15.7.2"
+      }
+    },
     "react-dev-utils": {
       "version": "11.0.4",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-11.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "govuk-react": "^0.9.0",
     "normalize.css": "^8.0.1",
     "react": "^17.0.2",
+    "react-debounce-input": "^3.2.3",
     "react-dom": "^17.0.2",
     "react-dropzone": "^11.3.4",
     "react-router-dom": "^5.2.0",

--- a/src/components/ChildSelector.tsx
+++ b/src/components/ChildSelector.tsx
@@ -1,15 +1,15 @@
 import * as GovUK from 'govuk-react';
 
 interface ChildSelectorProps {
-    childIds: Array<[number, number]>,
-    selected: number | null,
-    setSelected: (arg: number | null) => void,
+    childIds: Array<[string, number]>,
+    selected: string | null,
+    setSelected: (arg: string | null) => void,
 }
 
 export default function ChildSelector({ childIds, selected, setSelected }: ChildSelectorProps) {
   let rows = [];
   for (const [i, [childId, numErrors]] of childIds.entries()) {
-    let selectionTarget: number | null = childId;
+    let selectionTarget: string | null = childId;
     let cellStyle = null;
     
     if (childId === selected) {

--- a/src/components/ChildSelector.tsx
+++ b/src/components/ChildSelector.tsx
@@ -7,7 +7,6 @@ interface ChildSelectorProps {
 }
 
 export default function ChildSelector({ childIds, selected, setSelected }: ChildSelectorProps) {
-
   let rows = [];
   for (const [i, [childId, numErrors]] of childIds.entries()) {
     let selectionTarget: number | null = childId;

--- a/src/components/ErrorDisplay.tsx
+++ b/src/components/ErrorDisplay.tsx
@@ -10,9 +10,9 @@ interface ErrorDisplayProps {
 
 // The margin-bottom has to equal height + margin-top + border
 const ErrorStyles = styled.div`
-div {
+.floatingContainer {
   position: relative;
-  padding: 0 10px;
+  padding: 10px 10px;
   top: 0;
   left: 100px;
   width: 300px;
@@ -21,9 +21,13 @@ div {
   margin-bottom: -307px;
   border: 1px solid black;
   background-color: #fff;
-  overflow-y: auto;
   font-size: 10px;
 }  
+
+input {
+  height: 13px;
+  width: 180px;
+}
 
 table {
   font-size: 10px;
@@ -60,7 +64,10 @@ export default function ErrorDisplay({ validatedData, isShown }: ErrorDisplayPro
 
   return (
     <ErrorStyles>
-      <div style={{display: isShown ? 'block' : 'none', float: 'left', position: 'relative', 'top': 0, 'left': '100px', width: '300px'}}>
+      <div className='floatingContainer' style={{display: isShown ? 'block' : 'none'}}>
+        <input placeholder="Enter a child ID to filter..." />
+        <button style={{float: 'right'}}>Clear filters</button>
+        <p>Click each row to filter for only that error type.</p>
         <GovUK.Table>
           <GovUK.Table.Row>
             <GovUK.Table.CellHeader>Code</GovUK.Table.CellHeader>

--- a/src/components/ErrorDisplay.tsx
+++ b/src/components/ErrorDisplay.tsx
@@ -1,0 +1,75 @@
+import * as GovUK from 'govuk-react';
+import { useMemo, ReactElement } from 'react';
+import { ValidatedData } from './../types';
+import styled from 'styled-components';
+
+interface ErrorDisplayProps {
+  validatedData: ValidatedData,
+  isShown: boolean,
+}
+
+// The margin-bottom has to equal height + margin-top + border
+const ErrorStyles = styled.div`
+div {
+  position: relative;
+  padding: 0 10px;
+  top: 0;
+  left: 100px;
+  width: 300px;
+  height: 300px;
+  margin-top: 5px;
+  margin-bottom: -307px;
+  border: 1px solid black;
+  background-color: #fff;
+  overflow-y: auto;
+  font-size: 10px;
+}  
+
+table {
+  font-size: 10px;
+  overflow-y: auto;
+}
+`
+
+export default function ErrorDisplay({ validatedData, isShown }: ErrorDisplayProps): ReactElement {
+  let errorRows = useMemo<Array<ReactElement>>(() => {
+    let errorCounts = new Map();
+    validatedData.errors.forEach(locationToError => {
+      locationToError.forEach(errorCodes => {
+        errorCodes.forEach(errorCode => {
+          errorCounts.set(errorCode, errorCounts.get(errorCode) ? errorCounts.get(errorCode) + 1 : 1)
+        })
+      })
+    });
+
+    let errorRows: Array<ReactElement> = [];
+    errorCounts.forEach((count, errorCode) => {
+      let errorDetails = validatedData.errorDefinitions.get(errorCode);
+      
+      errorRows.push(
+        <GovUK.Table.Row key={errorCode}>
+          <GovUK.Table.Cell>{errorCode}</GovUK.Table.Cell>
+          <GovUK.Table.Cell>{errorDetails?.get('description')}</GovUK.Table.Cell>
+          <GovUK.Table.Cell>{count}</GovUK.Table.Cell>
+        </GovUK.Table.Row>
+      )
+    })
+
+    return errorRows
+  }, [validatedData])
+
+  return (
+    <ErrorStyles>
+      <div style={{display: isShown ? 'block' : 'none', float: 'left', position: 'relative', 'top': 0, 'left': '100px', width: '300px'}}>
+        <GovUK.Table>
+          <GovUK.Table.Row>
+            <GovUK.Table.CellHeader>Code</GovUK.Table.CellHeader>
+            <GovUK.Table.CellHeader>Message</GovUK.Table.CellHeader>
+            <GovUK.Table.CellHeader>Count</GovUK.Table.CellHeader>
+          </GovUK.Table.Row>
+          {errorRows}
+        </GovUK.Table>
+      </div>
+    </ErrorStyles>
+  )
+}

--- a/src/components/ErrorDisplay.tsx
+++ b/src/components/ErrorDisplay.tsx
@@ -1,4 +1,5 @@
 import * as GovUK from 'govuk-react';
+import { DebounceInput } from 'react-debounce-input';
 import { useMemo, ReactElement } from 'react';
 import { ValidatedData } from './../types';
 import styled from 'styled-components';
@@ -8,7 +9,7 @@ interface ErrorDisplayProps {
   isShown: boolean,
 }
 
-// The margin-bottom has to equal height + margin-top + border
+// The margin-bottom has to equal height + margin-top + border (top/bottom) + padding (top/bottom)
 const ErrorStyles = styled.div`
 .floatingContainer {
   position: relative;
@@ -18,7 +19,7 @@ const ErrorStyles = styled.div`
   width: 300px;
   height: 300px;
   margin-top: 5px;
-  margin-bottom: -307px;
+  margin-bottom: -327px;
   border: 1px solid black;
   background-color: #fff;
   font-size: 10px;
@@ -62,10 +63,11 @@ export default function ErrorDisplay({ validatedData, isShown }: ErrorDisplayPro
     return errorRows
   }, [validatedData])
 
+  // TODO: Debounced input
   return (
     <ErrorStyles>
       <div className='floatingContainer' style={{display: isShown ? 'block' : 'none'}}>
-        <input placeholder="Enter a child ID to filter..." />
+        <DebounceInput minLength={2} debounceTimeout={300} onChange={event => console.log(event)} placeholder="Enter a child ID to filter..." />
         <button style={{float: 'right'}}>Clear filters</button>
         <p>Click each row to filter for only that error type.</p>
         <GovUK.Table>

--- a/src/components/Validator.tsx
+++ b/src/components/Validator.tsx
@@ -16,6 +16,9 @@ export default function Validator({ validatedData }: ValidatorProps) {
   let [selectedChild, setSelectedChild] = useState<string | null>(null);
   let [errorDisplayShown, setErrorDisplayShown] = useState(false);
 
+  /**
+   * Filters the data that is shown to the selected child
+   */
   const filteredData = useMemo(() => {
     let filteredData: ParsedData = new Map();
     validatedData.data.forEach((_, key) => {
@@ -24,6 +27,10 @@ export default function Validator({ validatedData }: ValidatorProps) {
     return filteredData;
   }, [validatedData, selectedChild])
 
+  /**
+   * Computes a set of error locations used for highlighting. These are coordinates (index, columnName).
+   * The co-ordinates are then stringify-ed to allow hash comparison in a Set.
+   */
   const errorLocations = useMemo<ErrorLocations>(() => {
     const errorLocations = new Map();
     validatedData.errors.forEach((errorLocation, fileName) => {
@@ -42,6 +49,10 @@ export default function Validator({ validatedData }: ValidatorProps) {
     return errorLocations;
   }, [validatedData])
 
+  /**
+   * Computes the list of errors for each child.
+   * TODO: Current implementation is O(N * M) for N data, M child. Think can be O(N)
+   */
   const childIdsWithErrors = useMemo<Array<[string, Array<string>]>>(() => {
     let uniqueIds: Set<string> = new Set();
     let childIds: Array<[string, Array<string>]> = [];
@@ -55,7 +66,12 @@ export default function Validator({ validatedData }: ValidatorProps) {
     });
     return childIds;
   }, [validatedData])
-
+  
+  /**
+   * The child ID errors then get filtered to include only filtered Child IDs, or filtered errors.
+   * If a filter is not set it is assumed we should see everything.
+   * We then compute counts to pass to ChildSelector
+   */
   const filteredIdsWithErrorCounts = useMemo<Array<[string, number]>>(() => {
     let filteredIds: Array<[string, number]> = [];
     for (let [childId, errors] of childIdsWithErrors) {
@@ -64,7 +80,7 @@ export default function Validator({ validatedData }: ValidatorProps) {
       let errorMatches = errorFilter ? numErrors > 0 : true;
 
       if (childMatches && errorMatches) {
-        filteredIds.push([childId, numErrors])
+        filteredIds.push([childId, numErrors]);
       }
     }
     return filteredIds;

--- a/src/components/Validator.tsx
+++ b/src/components/Validator.tsx
@@ -3,6 +3,7 @@ import ChildSelector from './ChildSelector';
 import { useState, useMemo, ReactElement } from 'react';
 import DataTable from './DataTable';
 import TabbedData from './TabbedData';
+import ErrorDisplay from './ErrorDisplay';
 import { DataRow, ParsedData, ValidatedData, ErrorLocations } from './../types';
 
 interface ValidatorProps {
@@ -11,6 +12,7 @@ interface ValidatorProps {
 
 export default function Validator({ validatedData }: ValidatorProps) {
   let [selectedChild, setSelectedChild] = useState<number | null>(null);
+  let [errorDisplayShown, setErrorDisplayShown] = useState(false);
 
   const filteredData = useMemo(() => {
     let filteredData: ParsedData = new Map();
@@ -67,7 +69,11 @@ export default function Validator({ validatedData }: ValidatorProps) {
     <>
     <GovUK.GridRow mb={5}>
       <GovUK.GridCol setWidth='200px'>
-        <GovUK.H4>Child ID</GovUK.H4>
+        <div>
+          <GovUK.H4 mb={8} style={{'display': 'inline', 'marginRight': '10px'}}>Child ID</GovUK.H4>
+          <button onClick={() => {setErrorDisplayShown(!errorDisplayShown)}} style={{'display': 'inline'}}>Filter</button>
+        </div>
+        <ErrorDisplay validatedData={validatedData} isShown={errorDisplayShown} />
         <ChildSelector childIds={childIdsWithErrors} selected={selectedChild} setSelected={setSelectedChild} />
       </GovUK.GridCol>
       <GovUK.GridCol>


### PR DESCRIPTION
This PR includes a new ErrorDisplay component, which appears on dropdown for filtering. Changes include

- ErrorDisplay displays count and kinds of errors
- ErrorDisplay also allows filtering on child ID and by clicking errors
- These filters filter the ChildID in the validator.
- Child ID is now a string by default.
- Installed DebounceInput