### PR TITLE
Update validator release and send Python errors to Sentry

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+REACT_APP_VALIDATOR_RELEASE=quality-lac-data-validator==0.2.0a2

--- a/src/api.ts
+++ b/src/api.ts
@@ -75,7 +75,7 @@ export async function loadPyodide() {
       import logging
       logging.basicConfig(level=logging.INFO)
      
-      await micropip.install('quality-lac-data-validator==0.2.0a1')
+      await micropip.install('${process.env.REACT_APP_VALIDATOR_RELEASE}')
 
       try:
         for mod in micropip_extra_modules:

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,6 @@
 import { ValidatedData, UploadedFile, ErrorSelected, UploadMetadata } from './types';
 import {public_key} from "./helpers/postcodeSignature";
+import {captureException} from "./helpers/sentry";
 
 export async function handleUploaded903Data(uploadedFiles: Array<UploadedFile>, selectedErrors: Array<ErrorSelected>, metadata: UploadMetadata): Promise<[ValidatedData, Array<any>]> {
   const pyodide = window.pyodide;
@@ -37,10 +38,10 @@ export async function handleUploaded903Data(uploadedFiles: Array<UploadedFile>, 
                 
       `);
   } catch (error) {
-      console.log('Caught Error!')
-      console.log((error as Error).toString());
-      // We need to take the second to last line to get the exception text.
-      const errorLines = (error as Error).toString().split('\n')
+      console.error('Caught Error!', error)
+      const pythonError = (error as Error).toString()
+      captureException(error, {pythonError})
+      const errorLines = pythonError.split('\n') // We need to take the second to last line to get the exception text.
       uploadErrors.push(errorLines[errorLines.length - 2]);
   }
 

--- a/src/helpers/report/childErrorReport.ts
+++ b/src/helpers/report/childErrorReport.ts
@@ -1,5 +1,6 @@
 import {saveAs} from "file-saver";
 import dayjs from "dayjs";
+import {captureException} from "../sentry";
 
 export const saveErrorSummary = async (report_type: string) => {
     const time = dayjs().format('YYYYMMDD-HHmmss')
@@ -13,8 +14,9 @@ export const saveErrorSummary = async (report_type: string) => {
         report.destroy()
         saveAs(errorSummaryContent, `${report_type}-${time}.csv`);
     } catch (error) {
-        console.log('Caught Error!')
-        console.log((error as Error).toString());
+        console.error('Caught Error!', error)
+        const pythonError = (error as Error).toString()
+        captureException(error, {pythonError})
     }
 }
 
@@ -30,8 +32,9 @@ export const saveExcelSummary = async () => {
         report_data.destroy()
         saveAs(errorSummaryContent, `ErrorReport-${time}.xlsx`);
     } catch (error) {
-        console.log('Caught Error!')
-        console.log((error as Error).toString());
+        console.error('Caught Error!', error)
+        const pythonError = (error as Error).toString()
+        captureException(error, {pythonError})
     }
 }
 

--- a/src/helpers/sentry.js
+++ b/src/helpers/sentry.js
@@ -17,3 +17,10 @@ export const init = () => {
         console.error("Failed to initialise Sentry")
     }
 }
+
+export const captureException = (err, context) => {
+    try {
+        Sentry.captureException(err, context);
+    } catch {
+    }
+}


### PR DESCRIPTION
Validator release 0.2.0a2 fixing two bugs

Sentry around python calls - error messages not particularly helpful but at least we know. Further update likely to add more context information.