### PR TITLE
Track LA when validating

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -53,7 +53,7 @@ export default function Dashboard() {
   }, [])
 
   const runValidation = useCallback(async () => {
-    event('click', 'validate')
+    event('click', 'validate', window.localStorage.getItem('localAuthority');)
     setUploadErrors([]);
     setLoadingText("Loading postcode file (initial load takes 60 seconds)...");
     const metadata: UploadMetadata = {

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -53,7 +53,8 @@ export default function Dashboard() {
   }, [])
 
   const runValidation = useCallback(async () => {
-    event('click', 'validate', window.localStorage.getItem('localAuthority');)
+    let storedValue = window.localStorage.getItem('localAuthority') || 'LA not set!';
+    event('click', 'validate', storedValue);
     setUploadErrors([]);
     setLoadingText("Loading postcode file (initial load takes 60 seconds)...");
     const metadata: UploadMetadata = {

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -53,8 +53,14 @@ export default function Dashboard() {
   }, [])
 
   const runValidation = useCallback(async () => {
-    let storedValue = window.localStorage.getItem('localAuthority') || 'LA not set!';
-    event('click', 'validate', storedValue);
+    event('click', 'validate');
+    let storedValue = window.localStorage.getItem('localAuthority');
+    if (storedValue) {
+      event('validate', 'LA_known', storedValue);
+    } else {
+      event('validate', 'no_LA');
+    }
+
     setUploadErrors([]);
     setLoadingText("Loading postcode file (initial load takes 60 seconds)...");
     const metadata: UploadMetadata = {


### PR DESCRIPTION
At the moment we can only track when LA's select their LA and, I think, when the page sets the LA from localStorage. We're trying to track the LA every time validate is clicked so we can see if people are repeatedly using the tool in a session - not 100% sure if what I've done here is the right way to do it.

I've kept '`event('click' ,'validate')` as a thing but added `event('validate', 'LA_known', storedValue)` (and `event('validate', 'no_LA')` in case getting the LA from localStorage doesnt work for some reason)